### PR TITLE
Feature/bronze validate

### DIFF
--- a/backend/src/backend/db/migrations/env.py
+++ b/backend/src/backend/db/migrations/env.py
@@ -78,7 +78,10 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection, target_metadata=target_metadata
+            connection=connection,
+            target_metadata=target_metadata,
+            include_schemas=True,
+            version_table_schema="kiittime",
         )
 
         with context.begin_transaction():

--- a/backend/src/backend/db/migrations/versions/0dabea0c5b70_make_course_name_nullable.py
+++ b/backend/src/backend/db/migrations/versions/0dabea0c5b70_make_course_name_nullable.py
@@ -1,0 +1,32 @@
+"""make course_name nullable
+
+Revision ID: 0dabea0c5b70
+Revises: 301dc7c59778
+Create Date: 2026-07-12 19:42:51.606445
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '0dabea0c5b70'
+down_revision: Union[str, Sequence[str], None] = '301dc7c59778'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column('courses', 'course_name',
+               existing_type=sa.VARCHAR(),
+               nullable=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column('courses', 'course_name',
+               existing_type=sa.VARCHAR(),
+               nullable=False)

--- a/backend/src/backend/db/migrations/versions/301dc7c59778_add_bronze_snapshots_table.py
+++ b/backend/src/backend/db/migrations/versions/301dc7c59778_add_bronze_snapshots_table.py
@@ -1,0 +1,60 @@
+"""add bronze_snapshots table, explicit schema qualification on FKs
+
+Revision ID: 301dc7c59778
+Revises: 53f4fae4babb
+Create Date: 2026-07-12 19:06:03.898826
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '301dc7c59778'
+down_revision: Union[str, Sequence[str], None] = '53f4fae4babb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('bronze_snapshots',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uploaded_by', sa.String(), nullable=True),
+        sa.Column('uploaded_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('source_filename', sa.String(), nullable=False),
+        sa.Column('storage_path', sa.String(), nullable=True),
+        sa.Column('scope_section_ids', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('parsed_data', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('status', sa.Enum('pending', 'approved', 'rejected', name='snapshot_status', schema='kiittime'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        schema='kiittime'
+    )
+
+    # explicit schema-qualify the 4 FKs on class_sessions (was implicit via MetaData default)
+    op.drop_constraint('class_sessions_course_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+    op.drop_constraint('class_sessions_faculty_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+    op.drop_constraint('class_sessions_room_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+    op.drop_constraint('class_sessions_section_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+
+    op.create_foreign_key('class_sessions_course_id_fkey', 'class_sessions', 'courses', ['course_id'], ['id'], source_schema='kiittime', referent_schema='kiittime')
+    op.create_foreign_key('class_sessions_faculty_id_fkey', 'class_sessions', 'faculty', ['faculty_id'], ['id'], source_schema='kiittime', referent_schema='kiittime')
+    op.create_foreign_key('class_sessions_room_id_fkey', 'class_sessions', 'rooms', ['room_id'], ['id'], source_schema='kiittime', referent_schema='kiittime')
+    op.create_foreign_key('class_sessions_section_id_fkey', 'class_sessions', 'sections', ['section_id'], ['id'], source_schema='kiittime', referent_schema='kiittime')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('class_sessions_course_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+    op.drop_constraint('class_sessions_faculty_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+    op.drop_constraint('class_sessions_room_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+    op.drop_constraint('class_sessions_section_id_fkey', 'class_sessions', schema='kiittime', type_='foreignkey')
+
+    op.create_foreign_key('class_sessions_course_id_fkey', 'class_sessions', 'courses', ['course_id'], ['id'])
+    op.create_foreign_key('class_sessions_faculty_id_fkey', 'class_sessions', 'faculty', ['faculty_id'], ['id'])
+    op.create_foreign_key('class_sessions_room_id_fkey', 'class_sessions', 'rooms', ['room_id'], ['id'])
+    op.create_foreign_key('class_sessions_section_id_fkey', 'class_sessions', 'sections', ['section_id'], ['id'])
+
+    op.drop_table('bronze_snapshots', schema='kiittime')

--- a/backend/src/backend/db/models.py
+++ b/backend/src/backend/db/models.py
@@ -1,6 +1,15 @@
-from datetime import time
+from datetime import datetime, time
+from enum import Enum as PyEnum
 
-from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy import (
+    DateTime,
+    Enum,
+    ForeignKey,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.db.base import Base
@@ -8,6 +17,7 @@ from backend.db.base import Base
 
 class Course(Base):
     __tablename__ = "courses"
+    __table_args__ = {"schema": "kiittime"}
 
     id: Mapped[int] = mapped_column(primary_key=True)
     course_code: Mapped[str] = mapped_column(unique=True)
@@ -18,6 +28,7 @@ class Course(Base):
 
 class Faculty(Base):
     __tablename__ = "faculty"
+    __table_args__ = {"schema": "kiittime"}
 
     id: Mapped[int] = mapped_column(primary_key=True)
     faculty_name: Mapped[str] = mapped_column(unique=True)
@@ -27,6 +38,7 @@ class Faculty(Base):
 
 class Room(Base):
     __tablename__ = "rooms"
+    __table_args__ = {"schema": "kiittime"}
 
     id: Mapped[int] = mapped_column(primary_key=True)
     room_number: Mapped[str] = mapped_column(unique=True)
@@ -41,7 +53,10 @@ class Section(Base):
     section_name: Mapped[str]
     year: Mapped[int]
 
-    __table_args__ = (UniqueConstraint("section_name", "year"),)
+    __table_args__ = (
+        UniqueConstraint("section_name", "year"),
+        {"schema": "kiittime"},
+    )
 
     class_sessions: Mapped[list["ClassSession"]] = relationship(back_populates="section")
 
@@ -51,10 +66,10 @@ class ClassSession(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    section_id: Mapped[int] = mapped_column(ForeignKey("sections.id"))
-    course_id: Mapped[int] = mapped_column(ForeignKey("courses.id"))
-    faculty_id: Mapped[int] = mapped_column(ForeignKey("faculty.id"))
-    room_id: Mapped[int] = mapped_column(ForeignKey("rooms.id"))
+    section_id: Mapped[int] = mapped_column(ForeignKey("kiittime.sections.id"))
+    course_id: Mapped[int] = mapped_column(ForeignKey("kiittime.courses.id"))
+    faculty_id: Mapped[int] = mapped_column(ForeignKey("kiittime.faculty.id"))
+    room_id: Mapped[int] = mapped_column(ForeignKey("kiittime.rooms.id"))
 
     day: Mapped[str]
     period_number: Mapped[int]
@@ -62,9 +77,42 @@ class ClassSession(Base):
 
     __table_args__ = (
         UniqueConstraint("section_id", "day", "period_number"),
+        {"schema": "kiittime"},
     )
 
     section: Mapped["Section"] = relationship(back_populates="class_sessions")
     course: Mapped["Course"] = relationship(back_populates="class_sessions")
     faculty: Mapped["Faculty"] = relationship(back_populates="class_sessions")
     room: Mapped["Room"] = relationship(back_populates="class_sessions")
+
+
+class SnapshotStatus(PyEnum):
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+
+
+class BronzeSnapshot(Base):
+    __tablename__ = "bronze_snapshots"
+    __table_args__ = {"schema": "kiittime"}
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    uploaded_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    uploaded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    source_filename: Mapped[str] = mapped_column(String, nullable=False)
+    storage_path: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    scope_section_ids: Mapped[list[str]] = mapped_column(JSONB, nullable=False)
+    parsed_data: Mapped[list[dict]] = mapped_column(JSONB, nullable=False)
+
+    status: Mapped[SnapshotStatus] = mapped_column(
+        Enum(SnapshotStatus, name="snapshot_status", schema="kiittime"),
+        default=SnapshotStatus.pending,
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<BronzeSnapshot id={self.id} file={self.source_filename} status={self.status}>"

--- a/backend/src/backend/db/models.py
+++ b/backend/src/backend/db/models.py
@@ -21,7 +21,7 @@ class Course(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     course_code: Mapped[str] = mapped_column(unique=True)
-    course_name: Mapped[str]
+    course_name: Mapped[str | None] = mapped_column(nullable=True)
 
     class_sessions: Mapped[list["ClassSession"]] = relationship(back_populates="course")
 

--- a/backend/src/backend/pipeline/bronze.py
+++ b/backend/src/backend/pipeline/bronze.py
@@ -1,0 +1,35 @@
+from sqlalchemy.orm import Session
+
+from backend.db.models import BronzeSnapshot, SnapshotStatus
+from backend.pipeline.schemas import SessionRow  # adjust import to your actual SessionRow location
+
+
+def write_bronze_snapshot(
+    db: Session,
+    rows: list[SessionRow],
+    *,
+    source_filename: str,
+    uploaded_by: str | None = None,
+    storage_path: str | None = None,
+) -> BronzeSnapshot:
+    """
+    Persist a raw parsed upload as an immutable bronze record.
+
+    Does NOT touch silver/gold tables — this is audit-trail only.
+    Caller is responsible for committing (or rolling back) the transaction.
+    """
+    scope_section_ids = sorted({row.section for row in rows})
+
+    snapshot = BronzeSnapshot(
+        uploaded_by=uploaded_by,
+        source_filename=source_filename,
+        storage_path=storage_path,
+        scope_section_ids=scope_section_ids,
+        parsed_data=[row.model_dump(mode="json") for row in rows],
+        status=SnapshotStatus.pending,
+    )
+
+    db.add(snapshot)
+    db.flush()
+
+    return snapshot

--- a/backend/src/backend/pipeline/orchestrate.py
+++ b/backend/src/backend/pipeline/orchestrate.py
@@ -1,0 +1,51 @@
+from sqlalchemy.orm import Session
+
+from backend.db.models import BronzeSnapshot, SnapshotStatus
+from backend.pipeline.bronze import write_bronze_snapshot
+from backend.pipeline.resolve import ResolvedSession, resolve_all
+from backend.pipeline.schemas import SessionRow
+from backend.pipeline.validate import ValidationError, validate_resolved_sessions
+
+
+def process_upload(
+    db: Session,
+    rows: list[SessionRow],
+    *,
+    source_filename: str,
+    uploaded_by: str | None = None,
+    storage_path: str | None = None,
+) -> tuple[BronzeSnapshot, list[ResolvedSession]]:
+    """
+    Full Phase 3 pipeline entry point: bronze write -> resolve -> validate.
+
+    Design decision: bronze is ALWAYS written and kept, even if validation
+    fails downstream. Bronze is an audit trail of "what we received" — a bad
+    upload is still something that was received, and erasing that evidence
+    on failure would defeat the purpose of having an audit trail at all.
+    If validation fails, the bronze row's status is set to `rejected` so the
+    failure is visible in the record, and ValidationError is re-raised so
+    the caller (eventually: the Telegram bot) knows to stop and report it.
+    No gold writes happen in this function — that's Phase 4, deliberately
+    separate.
+
+    Caller is responsible for the final commit (or rollback) of the
+    transaction after this returns successfully.
+    """
+    snapshot = write_bronze_snapshot(
+        db,
+        rows,
+        source_filename=source_filename,
+        uploaded_by=uploaded_by,
+        storage_path=storage_path,
+    )
+
+    resolved = resolve_all(db, rows)
+
+    try:
+        validate_resolved_sessions(resolved)
+    except ValidationError:
+        snapshot.status = SnapshotStatus.rejected
+        db.flush()
+        raise
+
+    return snapshot, resolved

--- a/backend/src/backend/pipeline/resolve.py
+++ b/backend/src/backend/pipeline/resolve.py
@@ -1,0 +1,104 @@
+from datetime import time
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from backend.db.models import Course, Faculty, Room, Section
+from backend.pipeline.schemas import SessionRow
+
+
+class ResolvedSession(BaseModel):
+    section_id: int
+    course_id: int
+    faculty_id: int
+    room_id: int
+    day: str
+    period_number: int
+    start_time: time
+
+
+def resolve_all(db: Session, rows: list[SessionRow]) -> list[ResolvedSession]:
+    """
+    Batch-resolve every SessionRow's natural-key references (course, faculty,
+    room, section) to DB ids, creating any entities that don't exist yet.
+
+    Runs a fixed ~8 queries total, regardless of row count (no N+1).
+    Caller is responsible for committing (or rolling back) the transaction.
+    """
+
+    course_codes = {r.course_code for r in rows}
+    faculty_names = {r.faculty_name for r in rows}
+    room_numbers = {r.room_number for r in rows}
+    section_keys = {(r.section, r.year) for r in rows}
+
+    existing_courses = {
+        c.course_code: c
+        for c in db.execute(
+            select(Course).where(Course.course_code.in_(course_codes))
+        ).scalars()
+    }
+    missing_course_codes = course_codes - existing_courses.keys()
+    if missing_course_codes:
+        new_courses = [Course(course_code=code, course_name=None) for code in missing_course_codes]
+        db.add_all(new_courses)
+        db.flush()
+        existing_courses.update({c.course_code: c for c in new_courses})
+
+    existing_faculty = {
+        f.faculty_name: f
+        for f in db.execute(
+            select(Faculty).where(Faculty.faculty_name.in_(faculty_names))
+        ).scalars()
+    }
+    missing_faculty_names = faculty_names - existing_faculty.keys()
+    if missing_faculty_names:
+        new_faculty = [Faculty(faculty_name=name) for name in missing_faculty_names]
+        db.add_all(new_faculty)
+        db.flush()
+        existing_faculty.update({f.faculty_name: f for f in new_faculty})
+
+    existing_rooms = {
+        r.room_number: r
+        for r in db.execute(
+            select(Room).where(Room.room_number.in_(room_numbers))
+        ).scalars()
+    }
+    missing_room_numbers = room_numbers - existing_rooms.keys()
+    if missing_room_numbers:
+        new_rooms = [Room(room_number=num) for num in missing_room_numbers]
+        db.add_all(new_rooms)
+        db.flush()
+        existing_rooms.update({r.room_number: r for r in new_rooms})
+
+    existing_sections_list = db.execute(
+        select(Section).where(
+            Section.year.in_({y for (_, y) in section_keys})
+        )
+    ).scalars()
+    existing_sections = {
+        (s.section_name, s.year): s
+        for s in existing_sections_list
+        if (s.section_name, s.year) in section_keys
+    }
+    missing_section_keys = section_keys - existing_sections.keys()
+    if missing_section_keys:
+        new_sections = [
+            Section(section_name=name, year=year) for name, year in missing_section_keys
+        ]
+        db.add_all(new_sections)
+        db.flush()
+        existing_sections.update({(s.section_name, s.year): s for s in new_sections})
+
+    return [
+        ResolvedSession(
+            section_id=existing_sections[(r.section, r.year)].id,
+            course_id=existing_courses[r.course_code].id,
+            faculty_id=existing_faculty[r.faculty_name].id,
+            room_id=existing_rooms[r.room_number].id,
+            day=r.day,
+            period_number=r.period_number,
+            start_time=r.start_time,
+        )
+        for r in rows
+    ]

--- a/backend/src/backend/pipeline/validate.py
+++ b/backend/src/backend/pipeline/validate.py
@@ -1,0 +1,28 @@
+from collections import Counter
+
+from backend.pipeline.resolve import ResolvedSession
+
+
+class ValidationError(Exception):
+    """Raised when a batch of ResolvedSessions fails validation before gold upsert."""
+
+
+def validate_resolved_sessions(sessions: list[ResolvedSession]) -> None:
+    """
+    Check a batch of ResolvedSessions for conflicts before they're eligible
+    for gold upsert. Raises ValidationError with details if any check fails.
+
+    Currently checks:
+    - No two sessions claim the same (section_id, day, period_number) slot.
+    """
+    slot_counts = Counter(
+        (s.section_id, s.day, s.period_number) for s in sessions
+    )
+    conflicts = [slot for slot, count in slot_counts.items() if count > 1]
+
+    if conflicts:
+        details = "; ".join(
+            f"section_id={sid}, day={day}, period={period}"
+            for sid, day, period in conflicts
+        )
+        raise ValidationError(f"Duplicate session slots found: {details}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,3 @@
+from dotenv import load_dotenv
+
+load_dotenv()

--- a/backend/tests/pipeline/test_bronze.py
+++ b/backend/tests/pipeline/test_bronze.py
@@ -1,0 +1,70 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from backend.db.models import BronzeSnapshot, SnapshotStatus
+from backend.pipeline.bronze import write_bronze_snapshot
+from backend.pipeline.schemas import SessionRow
+
+
+@pytest.fixture
+def db():
+    import os
+    database_url = os.getenv("DATABASE_URL")
+    engine = create_engine(database_url)
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+def make_row(**overrides) -> SessionRow:
+    defaults = dict(
+        year=2026, section="CSE1", day="Mon", period_number=1,
+        start_time="08:00", course_code="DBMS", faculty_name="Dr. Test",
+        room_number="C25-B001",
+    )
+    defaults.update(overrides)
+    return SessionRow(**defaults)
+
+
+def test_writes_snapshot_with_pending_status(db):
+    rows = [make_row()]
+    snapshot = write_bronze_snapshot(
+        db, rows, source_filename="test.xlsx", uploaded_by="tester"
+    )
+
+    assert snapshot.id is not None
+    assert snapshot.status == SnapshotStatus.pending
+    assert snapshot.source_filename == "test.xlsx"
+    assert snapshot.uploaded_by == "tester"
+
+
+def test_scope_section_ids_captures_distinct_sections(db):
+    rows = [
+        make_row(section="CSE1", period_number=1),
+        make_row(section="CSE1", period_number=2),
+        make_row(section="CSE2", period_number=1),
+    ]
+    snapshot = write_bronze_snapshot(db, rows, source_filename="test.xlsx")
+
+    assert sorted(snapshot.scope_section_ids) == ["CSE1", "CSE2"]
+
+
+def test_parsed_data_round_trips_row_count(db):
+    rows = [make_row(period_number=i) for i in range(1, 4)]
+    snapshot = write_bronze_snapshot(db, rows, source_filename="test.xlsx")
+
+    assert len(snapshot.parsed_data) == 3
+
+
+def test_persisted_snapshot_retrievable_after_flush(db):
+    rows = [make_row()]
+    snapshot = write_bronze_snapshot(db, rows, source_filename="test.xlsx")
+
+    fetched = db.get(BronzeSnapshot, snapshot.id)
+    assert fetched is not None
+    assert fetched.source_filename == "test.xlsx"

--- a/backend/tests/pipeline/test_orchestrate.py
+++ b/backend/tests/pipeline/test_orchestrate.py
@@ -1,0 +1,55 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from backend.db.models import SnapshotStatus
+from backend.pipeline.orchestrate import process_upload
+from backend.pipeline.schemas import SessionRow
+from backend.pipeline.validate import ValidationError
+
+
+@pytest.fixture
+def db():
+    import os
+    database_url = os.getenv("DATABASE_URL")
+    engine = create_engine(database_url)
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+def make_row(**overrides) -> SessionRow:
+    defaults = dict(
+        year=2026, section="CSE1", day="Mon", period_number=1,
+        start_time="08:00", course_code="DBMS", faculty_name="Dr. Test",
+        room_number="C25-B001",
+    )
+    defaults.update(overrides)
+    return SessionRow(**defaults)
+
+
+def test_successful_upload_returns_snapshot_and_resolved_sessions(db):
+    rows = [make_row(period_number=1), make_row(period_number=2)]
+    snapshot, resolved = process_upload(db, rows, source_filename="test.xlsx")
+
+    assert snapshot.status == SnapshotStatus.pending
+    assert len(resolved) == 2
+
+
+def test_validation_failure_marks_snapshot_rejected_but_keeps_it(db):
+    rows = [
+        make_row(period_number=1, course_code="DBMS"),
+        make_row(period_number=1, course_code="OS"),  # same slot, conflict
+    ]
+
+    with pytest.raises(ValidationError):
+        process_upload(db, rows, source_filename="bad.xlsx")
+
+    # bronze snapshot should still exist and be marked rejected, not vanished
+    from backend.db.models import BronzeSnapshot
+    snapshot = db.query(BronzeSnapshot).filter_by(source_filename="bad.xlsx").one()
+    assert snapshot.status == SnapshotStatus.rejected

--- a/backend/tests/pipeline/test_resolve.py
+++ b/backend/tests/pipeline/test_resolve.py
@@ -1,0 +1,90 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from backend.db.models import Course, Faculty, Room, Section
+from backend.pipeline.resolve import resolve_all
+from backend.pipeline.schemas import SessionRow
+
+
+@pytest.fixture
+def db():
+    """Fresh transactional session per test, rolled back after — never commits."""
+    import os
+    database_url = os.getenv("DATABASE_URL")
+    engine = create_engine(database_url)
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+def make_row(**overrides) -> SessionRow:
+    defaults = dict(
+        year=1, section="CSE1", day="Mon", period_number=1,
+        start_time="08:00", course_code="DBMS", faculty_name="Dr. Test",
+        room_number="C25-B001",
+    )
+    defaults.update(overrides)
+    return SessionRow(**defaults)
+
+
+def test_creates_new_entities_when_none_exist(db):
+    rows = [make_row()]
+    resolved = resolve_all(db, rows)
+
+    assert len(resolved) == 1
+    assert db.query(Course).filter_by(course_code="DBMS").one().course_name is None
+    assert db.query(Faculty).filter_by(faculty_name="Dr. Test").count() == 1
+    assert db.query(Room).filter_by(room_number="C25-B001").count() == 1
+    assert db.query(Section).filter_by(section_name="CSE1", year=1).count() == 1
+
+
+def test_reuses_existing_entities_no_duplicates(db):
+    existing = Course(course_code="DBMS", course_name=None)
+    db.add(existing)
+    db.flush()
+
+    rows = [make_row(course_code="DBMS")]
+    resolved = resolve_all(db, rows)
+
+    assert resolved[0].course_id == existing.id
+    assert db.query(Course).filter_by(course_code="DBMS").count() == 1
+
+
+def test_dedupes_repeated_references_within_one_upload(db):
+    rows = [
+        make_row(period_number=1, course_code="DBMS", faculty_name="Dr. Test"),
+        make_row(period_number=2, course_code="DBMS", faculty_name="Dr. Test"),
+    ]
+    resolved = resolve_all(db, rows)
+
+    assert db.query(Course).filter_by(course_code="DBMS").count() == 1
+    assert resolved[0].course_id == resolved[1].course_id
+
+
+def test_different_rooms_same_course_resolve_independently(db):
+    rows = [
+        make_row(period_number=1, room_number="C25-B001"),
+        make_row(period_number=2, room_number="C25-B002"),
+    ]
+    resolved = resolve_all(db, rows)
+
+    assert resolved[0].room_id != resolved[1].room_id
+    assert db.query(Room).count() == 2
+
+
+def test_section_composite_key_same_name_different_year(db):
+    rows = [
+        make_row(section="CSE1", year=1),
+        make_row(section="CSE1", year=2),
+    ]
+    resolved = resolve_all(db, rows)
+
+    assert resolved[0].section_id != resolved[1].section_id
+    assert db.query(Section).count() == 2

--- a/backend/tests/pipeline/test_validate.py
+++ b/backend/tests/pipeline/test_validate.py
@@ -1,0 +1,39 @@
+import pytest
+from datetime import time
+
+from backend.pipeline.resolve import ResolvedSession
+from backend.pipeline.validate import ValidationError, validate_resolved_sessions
+
+
+def make_resolved(**overrides) -> ResolvedSession:
+    defaults = dict(
+        section_id=1, course_id=1, faculty_id=1, room_id=1,
+        day="Mon", period_number=1, start_time=time(8, 0),
+    )
+    defaults.update(overrides)
+    return ResolvedSession(**defaults)
+
+
+def test_no_conflict_passes_silently():
+    sessions = [
+        make_resolved(period_number=1),
+        make_resolved(period_number=2),
+    ]
+    validate_resolved_sessions(sessions)  # should not raise
+
+
+def test_duplicate_slot_raises_validation_error():
+    sessions = [
+        make_resolved(section_id=1, day="Mon", period_number=1, course_id=1),
+        make_resolved(section_id=1, day="Mon", period_number=1, course_id=2),
+    ]
+    with pytest.raises(ValidationError):
+        validate_resolved_sessions(sessions)
+
+
+def test_same_period_different_sections_is_fine():
+    sessions = [
+        make_resolved(section_id=1, day="Mon", period_number=1),
+        make_resolved(section_id=2, day="Mon", period_number=1),
+    ]
+    validate_resolved_sessions(sessions)  # should not raise, different sections


### PR DESCRIPTION
This pull request introduces a new "bronze" audit-trail phase to the pipeline, refactors models and migrations for explicit schema usage, and implements the initial end-to-end upload, resolve, and validate logic, along with comprehensive tests. The main themes are: database schema changes, pipeline implementation, and testing.

**Database schema changes:**

* Added a new `bronze_snapshots` table (with explicit `kiittime` schema and status enum) to store immutable records of uploaded session data for auditing. Foreign keys on `class_sessions` are now explicitly schema-qualified. (`[[1]](diffhunk://#diff-2dfd7514dadb0787c0f99b139d02190fae26f9383fde9c0a894424eeec9eefe8R1-R60)`, `[[2]](diffhunk://#diff-ad5a851a234df474c5a8dae827b78d29ffa66d9abf0e0beb5bdbb1bfe5df264eL54-R118)`, `[[3]](diffhunk://#diff-1c55a31f39f1db183cc6206f3def1bd30776ec7a72fac4da1d37b21dfcba8f7cL81-R84)`)
* Made `course_name` nullable in the `courses` table to allow creation of new courses with only a code. (`[[1]](diffhunk://#diff-ab7eaed6332c90664b124502b67be43b3b26323ab2f2aa15a0468641b7df754eR1-R32)`, `[[2]](diffhunk://#diff-ad5a851a234df474c5a8dae827b78d29ffa66d9abf0e0beb5bdbb1bfe5df264eL1-R31)`)
* All main tables (`courses`, `faculty`, `rooms`, `sections`, `class_sessions`) now explicitly specify the `kiittime` schema in both models and migrations. (`[[1]](diffhunk://#diff-ad5a851a234df474c5a8dae827b78d29ffa66d9abf0e0beb5bdbb1bfe5df264eL1-R31)`, `[[2]](diffhunk://#diff-ad5a851a234df474c5a8dae827b78d29ffa66d9abf0e0beb5bdbb1bfe5df264eR41)`, `[[3]](diffhunk://#diff-ad5a851a234df474c5a8dae827b78d29ffa66d9abf0e0beb5bdbb1bfe5df264eL44-R59)`, `[[4]](diffhunk://#diff-ad5a851a234df474c5a8dae827b78d29ffa66d9abf0e0beb5bdbb1bfe5df264eL54-R118)`)

**Pipeline implementation:**

* Implemented `write_bronze_snapshot` to persist a raw upload as a bronze snapshot for audit, without affecting gold/silver tables. (`[backend/src/backend/pipeline/bronze.pyR1-R35](diffhunk://#diff-3a8a673477130b1c0c1483333eaf1d867acf7cd9da493cfb00e6b18ab8bf7e5bR1-R35)`)
* Added `resolve_all` to resolve natural keys in uploaded data to database IDs, creating missing entities as needed; and `validate_resolved_sessions` to check for duplicate session slots. (`[[1]](diffhunk://#diff-2b143e1855af05440d0fa8f526da0ba659e2fe05be6b445b8fd06fbbc5f77638R1-R104)`, `[[2]](diffhunk://#diff-780978c493d2eee45dd31c7cf4effd57c7d54c77233e7be4b74653a5a74c61e3R1-R28)`)
* Created `process_upload`, the main orchestration entry point: writes bronze, resolves, validates, and updates snapshot status on failure, but never deletes the bronze record. (`[backend/src/backend/pipeline/orchestrate.pyR1-R51](diffhunk://#diff-f28817342d9bc9847ce5cc311e0706ed68b9f64d1c716926c486e4bb97e5bdf2R1-R51)`)

**Testing:**

* Added tests for bronze snapshot writing and retrieval, ensuring correct status, section scoping, and data round-trip. (`[backend/tests/pipeline/test_bronze.pyR1-R70](diffhunk://#diff-8a6cd0265ed176210fbf00ad25392dd9162011376ca92155fe97418edd10594aR1-R70)`)
* Added tests for the full upload orchestration, including validation failure handling and audit-trail retention. (`[backend/tests/pipeline/test_orchestrate.pyR1-R55](diffhunk://#diff-e04cdc7602f3028953bf5502cc32b904f86e3f4e8ad26234f6869a59614f6296R1-R55)`)
* Test environment now loads `.env` for database configuration. (`[backend/tests/conftest.pyR1-R3](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR1-R3)`)