### PR TITLE
Persist active roll number and academic year, implement OTP rate limit UI

### DIFF
--- a/.scratch/fix-roll-no-localstorage/issues/01-mobile-storage-utils.md
+++ b/.scratch/fix-roll-no-localstorage/issues/01-mobile-storage-utils.md
@@ -1,0 +1,10 @@
+Status: resolved
+
+# Implement mobile storage utilities
+
+In `mobile/src/lib/storage.ts`:
+- [x] Define constants for `kiit-time:active-roll-no` and `kiit-time:active-academic-year`
+- [x] Export `getActiveRollNo`, `setActiveRollNo`, `clearActiveRollNo`
+- [x] Export `getActiveAcademicYear`, `setActiveAcademicYear`, `clearActiveAcademicYear`
+
+(Note: `clearActiveRollNo` and `clearActiveAcademicYear` are already imported by `mobile/src/components/settings-sheet.tsx`, so adding them will resolve the pending import).

--- a/.scratch/fix-roll-no-localstorage/issues/02-web-constants-and-reset.md
+++ b/.scratch/fix-roll-no-localstorage/issues/02-web-constants-and-reset.md
@@ -1,0 +1,10 @@
+Status: resolved
+
+# Implement web storage constants and reset logic
+
+In `webapp/src/lib/storage.ts` (equivalent storage file):
+- [x] Define constants for `ACTIVE_ROLL_NO_KEY` and `ACTIVE_ACADEMIC_YEAR_KEY`.
+
+In `webapp/src/routes/timetable.tsx`:
+- [x] Replace raw string `"kiit-time:active-roll-no"` and `"kiit-time:active-academic-year"` with constants.
+- [x] Update `handleReset` to call `localStorage.removeItem()` for both keys.

--- a/.scratch/fix-roll-no-localstorage/issues/03-wire-up-setters.md
+++ b/.scratch/fix-roll-no-localstorage/issues/03-wire-up-setters.md
@@ -1,0 +1,11 @@
+Status: resolved
+
+# Wire up Setters on Onboarding and OTP
+
+## Web App:
+- [x] In `webapp/src/components/Landing.tsx`, after `fetchRollNumberMapping` succeeds, `localStorage.setItem` the roll number and `data.academic_year`.
+- [x] In `webapp/src/components/SectionSearch.tsx`, after `verifyOtp` succeeds, `localStorage.setItem` the roll number and `data.academic_year`.
+
+## Mobile App:
+- [x] In `mobile/src/app/index.tsx`, after `fetchRollNumberMapping` succeeds, call `setActiveRollNo` and `setActiveAcademicYear(data.academic_year)`.
+- [x] In `mobile/src/app/select/sections.tsx`, after `verifyOtp` succeeds, call `setActiveRollNo` and `setActiveAcademicYear(data.academic_year)`.

--- a/.scratch/fix-roll-no-localstorage/spec.md
+++ b/.scratch/fix-roll-no-localstorage/spec.md
@@ -1,0 +1,44 @@
+Status: ready-for-agent
+
+## Problem Statement
+
+When a user onboards via roll number fetching or OTP verification on both the Web and Mobile apps, their `active-roll-no` and `active-academic-year` are currently not being persisted into local storage. However, the timetable view expects to read these values to display the user's active roll number and enable the edit sections flow (via the pencil icon). 
+
+## Solution
+
+We need to persist the active roll number and academic year into storage (LocalStorage for Web, AsyncStorage for Mobile) when onboarding is completed (in `Landing.tsx` / `index.tsx`) and when OTP verification succeeds (in `SectionSearch.tsx` / `select/sections.tsx`). Furthermore, when the user resets the timetable, these keys must be explicitly cleared to ensure proper reset state.
+
+## User Stories
+
+1. As a user, I want my active roll number and academic year to be saved after I fetch my roll number mapping, so that the timetable view remembers my identity across sessions and allows me to edit my sections.
+2. As a user, I want my active roll number and academic year to be saved after I verify via OTP, so that my identity is linked to the sections I manually selected.
+3. As a user, I want my roll number and academic year data to be cleared from storage when I reset my timetable, so that no residual user identity remains on the device.
+4. As a developer, I want the web app to use constants for storage keys rather than raw strings, so that I don't accidentally introduce typos when reading/writing to `localStorage`.
+5. As a developer, I want the mobile app to have explicit getter, setter, and clearer functions for active roll number and academic year in the central `storage.ts` module, so that platform-specific storage is safely abstracted.
+
+## Implementation Decisions
+
+- The web app (`webapp/src/routes/timetable.tsx`, `Landing.tsx`, `SectionSearch.tsx`) will be updated to use defined string constants for `kiit-time:active-roll-no` and `kiit-time:active-academic-year`.
+- We will update `webapp/src/components/Landing.tsx` and `webapp/src/components/SectionSearch.tsx` to set both keys after successfully obtaining `RollNumberMappingOut` from the API.
+- We will update `handleReset` in `webapp/src/routes/timetable.tsx` to call `removeItem` on these keys.
+- For the mobile app, we will define `getActiveRollNo`, `setActiveRollNo`, `clearActiveRollNo`, `getActiveAcademicYear`, `setActiveAcademicYear`, and `clearActiveAcademicYear` in `mobile/src/lib/storage.ts`.
+- We will invoke these setters in `mobile/src/app/index.tsx` (after fetching) and `mobile/src/app/select/sections.tsx` (after verifying OTP).
+- The mobile app's reset logic (in `mobile/src/components/settings-sheet.tsx`) already attempts to call these clear functions, so defining them will resolve the missing implementation.
+
+## Testing Decisions
+
+- The testing seam will be local manual verification.
+- We will test the web flow by monitoring `localStorage` through devtools during the onboarding and OTP flows.
+- We will test the mobile flow by logging or using a debugger to verify `AsyncStorage` during onboarding and OTP.
+- Test that the edit pencil icon appears successfully after onboarding and navigating to the timetable.
+- Test that the edit pencil icon disappears successfully after resetting the timetable.
+
+## Out of Scope
+
+- Introducing a global state manager (like Zustand) to replace the current direct storage usage.
+- Refactoring the entire API layer.
+- Changing the layout or UI of the timetable or onboarding flow.
+
+## Further Notes
+
+- `active-academic-year` will be populated directly from the `academic_year` field of the `RollNumberMappingOut` response.

--- a/.scratch/roll-number-mapping/issues/09-client-ui-otp-rate-limiting.md
+++ b/.scratch/roll-number-mapping/issues/09-client-ui-otp-rate-limiting.md
@@ -4,9 +4,9 @@
 
 **Blocked by:** 06 — Client UI: OTP Linking Flow, 08 — Backend OTP Best Practices
 
-**Status:** todo
+**Status:** completed
 
-- [ ] Implement a visual 60-second countdown timer on the "Resend OTP" button in the `mobile` app, disabling the button until it expires.
-- [ ] Implement a visual 60-second countdown timer on the "Resend OTP" button in the `webapp`, disabling the button until it expires.
-- [ ] Handle 429 Too Many Requests errors from the backend on the `POST /api/auth/otp/send` endpoint, displaying a user-friendly toast/alert.
-- [ ] Handle attempt lockout errors (e.g., 403 or 429) from the `POST /api/auth/otp/verify` endpoint if the user exceeds 3 failed attempts, showing an appropriate warning.
+- [x] Implement a visual 60-second countdown timer on the "Resend OTP" button in the `mobile` app, disabling the button until it expires.
+- [x] Implement a visual 60-second countdown timer on the "Resend OTP" button in the `webapp`, disabling the button until it expires.
+- [x] Handle 429 Too Many Requests errors from the backend on the `POST /api/auth/otp/send` endpoint, displaying a user-friendly toast/alert.
+- [x] Handle attempt lockout errors (e.g., 403 or 429) from the `POST /api/auth/otp/verify` endpoint if the user exceeds 3 failed attempts, showing an appropriate warning.

--- a/mobile/src/app/index.tsx
+++ b/mobile/src/app/index.tsx
@@ -8,7 +8,7 @@ import { AboutDialog } from '@/components/about-dialog';
 import { Icon } from '@/components/ui/icon';
 import { Text } from '@/components/ui/text';
 import { timetableHref } from '@/lib/search-params';
-import { getSavedSectionIds, saveSectionIds, saveTempLinkingRollNo, clearTempLinkingRollNo } from '@/lib/storage';
+import { getSavedSectionIds, saveSectionIds, saveTempLinkingRollNo, clearTempLinkingRollNo, setActiveRollNo, setActiveAcademicYear } from '@/lib/storage';
 import { fetchRollNumberMapping } from '@/lib/api';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -60,6 +60,8 @@ export default function Index() {
       const data = await fetchRollNumberMapping(rollNo.trim());
       const sectionIds = data.sections.map((s) => s.id);
       await saveSectionIds(sectionIds);
+      await setActiveRollNo(data.roll_no);
+      await setActiveAcademicYear(data.academic_year);
       router.replace(timetableHref(sectionIds));
     } catch (err: any) {
       if (err.status === 404 && err.detail === 'No timetables uploaded yet') {

--- a/mobile/src/app/select/sections.tsx
+++ b/mobile/src/app/select/sections.tsx
@@ -16,7 +16,7 @@ import { useSections } from '@/hooks/useSections';
 import { buildMailto } from '@/lib/mailto';
 import { extractPrefixes, filterSections } from '@/lib/sections';
 import { timetableHref } from '@/lib/search-params';
-import { saveSectionIds, getTempLinkingRollNo, clearTempLinkingRollNo } from '@/lib/storage';
+import { saveSectionIds, getTempLinkingRollNo, clearTempLinkingRollNo, setActiveRollNo, setActiveAcademicYear } from '@/lib/storage';
 import { cn } from '@/lib/utils';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { sendOtp, verifyOtp } from '@/lib/api';
@@ -73,6 +73,16 @@ export default function SectionSearch() {
 
   const otpInputRef = useRef<TextInput>(null);
 
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  useEffect(() => {
+    if (resendCooldown <= 0) return;
+    const timer = setInterval(() => {
+      setResendCooldown((prev) => prev - 1);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [resendCooldown]);
+
   useEffect(() => {
     (async () => {
       const val = await getTempLinkingRollNo();
@@ -121,10 +131,19 @@ export default function SectionSearch() {
       await sendOtp(rollNoToLink, selectedIds);
       setIsConfirmLinkOpen(false);
       setIsOtpOpen(true);
+      setResendCooldown(60);
     } catch (err: any) {
       const msg = err.message || 'Failed to send OTP. Please try again.';
       setOtpError(msg);
       toast.error(msg);
+      if (err.status === 429) {
+        const match = msg.match(/Please wait (\d+) seconds/i);
+        if (match) {
+          setResendCooldown(parseInt(match[1], 10));
+        } else {
+          setResendCooldown(60);
+        }
+      }
     } finally {
       setIsSendingOtp(false);
     }
@@ -138,11 +157,16 @@ export default function SectionSearch() {
       const data = await verifyOtp(rollNoToLink, otp);
       const sectionIds = data.sections.map((s) => s.id);
       await saveSectionIds(sectionIds);
+      await setActiveRollNo(rollNoToLink);
+      await setActiveAcademicYear(data.academic_year);
       await clearTempLinkingRollNo();
       setIsOtpOpen(false);
       router.replace(timetableHref(sectionIds));
     } catch (err: any) {
       setOtpError(err.message || 'Invalid OTP code.');
+      if (err.status === 429) {
+        toast.error(err.message || 'Too many failed attempts. Account locked.');
+      }
     } finally {
       setIsVerifyingOtp(false);
     }
@@ -401,10 +425,12 @@ export default function SectionSearch() {
               </Pressable>
               
               <Pressable
-                disabled={isSendingOtp}
+                disabled={isSendingOtp || resendCooldown > 0}
                 onPress={handleSendOtp}
                 className="w-full h-12 items-center justify-center">
-                <Text className="text-brand font-semibold text-sm">Resend Code</Text>
+                <Text className="text-brand font-semibold text-sm">
+                  {resendCooldown > 0 ? `Resend Code (${resendCooldown}s)` : 'Resend Code'}
+                </Text>
               </Pressable>
 
               <Pressable

--- a/mobile/src/lib/storage.ts
+++ b/mobile/src/lib/storage.ts
@@ -40,6 +40,8 @@ export async function setLastSeenAnnouncementId(id: number): Promise<void> {
 }
 
 const TEMP_LINKING_ROLL_NO_KEY = 'kiit-time:temp-linking-roll-no';
+const ACTIVE_ROLL_NO_KEY = 'kiit-time:active-roll-no';
+const ACTIVE_ACADEMIC_YEAR_KEY = 'kiit-time:active-academic-year';
 
 export async function getTempLinkingRollNo(): Promise<string | null> {
   return AsyncStorage.getItem(TEMP_LINKING_ROLL_NO_KEY);
@@ -52,4 +54,37 @@ export async function saveTempLinkingRollNo(rollNo: string): Promise<void> {
 export async function clearTempLinkingRollNo(): Promise<void> {
   await AsyncStorage.removeItem(TEMP_LINKING_ROLL_NO_KEY);
 }
+
+export async function getActiveRollNo(): Promise<string | null> {
+  return AsyncStorage.getItem(ACTIVE_ROLL_NO_KEY);
+}
+
+export async function setActiveRollNo(rollNo: string): Promise<void> {
+  await AsyncStorage.setItem(ACTIVE_ROLL_NO_KEY, rollNo);
+}
+
+export async function clearActiveRollNo(): Promise<void> {
+  await AsyncStorage.removeItem(ACTIVE_ROLL_NO_KEY);
+}
+
+export async function getActiveAcademicYear(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(ACTIVE_ACADEMIC_YEAR_KEY);
+    if (!raw) return null;
+    const parsed = parseInt(raw, 10);
+    if (isNaN(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function setActiveAcademicYear(year: number): Promise<void> {
+  await AsyncStorage.setItem(ACTIVE_ACADEMIC_YEAR_KEY, String(year));
+}
+
+export async function clearActiveAcademicYear(): Promise<void> {
+  await AsyncStorage.removeItem(ACTIVE_ACADEMIC_YEAR_KEY);
+}
+
 

--- a/webapp/src/components/Landing.tsx
+++ b/webapp/src/components/Landing.tsx
@@ -12,7 +12,7 @@ import {
 	DialogTitle,
 } from "#/components/ui/dialog";
 import { fetchRollNumberMapping } from "#/lib/api";
-import { saveSectionIds } from "#/lib/storage";
+import { saveSectionIds, ACTIVE_ROLL_NO_KEY, ACTIVE_ACADEMIC_YEAR_KEY } from "#/lib/storage";
 
 export function Landing() {
 	const [rollNo, setRollNo] = useState("");
@@ -37,6 +37,8 @@ export function Landing() {
 		try {
 			const data = await fetchRollNumberMapping(rollNo.trim());
 			saveSectionIds(data.sections.map((s) => s.id));
+			localStorage.setItem(ACTIVE_ROLL_NO_KEY, data.roll_no);
+			localStorage.setItem(ACTIVE_ACADEMIC_YEAR_KEY, String(data.academic_year));
 			navigate({
 				to: "/timetable",
 				search: { section_id: data.sections.map((s) => s.id) },

--- a/webapp/src/components/SectionSearch.tsx
+++ b/webapp/src/components/SectionSearch.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "#/components/ui/badge";
 import {
@@ -22,7 +22,7 @@ import {
 import { useSections } from "#/hooks/useSections";
 import { sendOtp, verifyOtp } from "#/lib/api";
 import { buildMailto } from "#/lib/mailto";
-import { saveSectionIds } from "#/lib/storage";
+import { saveSectionIds, ACTIVE_ROLL_NO_KEY, ACTIVE_ACADEMIC_YEAR_KEY } from "#/lib/storage";
 
 export function SectionSearch({ year }: { year: number }) {
 	const navigate = useNavigate();
@@ -39,6 +39,15 @@ export function SectionSearch({ year }: { year: number }) {
 	const [isSendingOtp, setIsSendingOtp] = useState(false);
 	const [isVerifyingOtp, setIsVerifyingOtp] = useState(false);
 	const [isOtpInputFocused, setIsOtpInputFocused] = useState(false);
+	const [resendCooldown, setResendCooldown] = useState(0);
+
+	useEffect(() => {
+		if (resendCooldown <= 0) return;
+		const timer = setInterval(() => {
+			setResendCooldown((prev) => prev - 1);
+		}, 1000);
+		return () => clearInterval(timer);
+	}, [resendCooldown]);
 
 	const otpInputRef = useRef<HTMLInputElement>(null);
 	const rollNoToLink = localStorage.getItem("temp_linking_roll_no");
@@ -112,10 +121,19 @@ export function SectionSearch({ year }: { year: number }) {
 			await sendOtp(rollNoToLink, selectedIds);
 			setIsConfirmLinkOpen(false);
 			setIsOtpOpen(true);
+			setResendCooldown(60);
 		} catch (err: any) {
 			const msg = err.message || "Failed to send OTP. Please try again.";
 			setOtpError(msg);
 			toast.error(msg);
+			if (err.status === 429) {
+				const match = msg.match(/Please wait (\d+) seconds/i);
+				if (match) {
+					setResendCooldown(parseInt(match[1], 10));
+				} else {
+					setResendCooldown(60);
+				}
+			}
 		} finally {
 			setIsSendingOtp(false);
 		}
@@ -129,6 +147,8 @@ export function SectionSearch({ year }: { year: number }) {
 			const data = await verifyOtp(rollNoToLink, otp);
 			saveSectionIds(data.sections.map((s) => s.id));
 			localStorage.removeItem("temp_linking_roll_no");
+			localStorage.setItem(ACTIVE_ROLL_NO_KEY, rollNoToLink);
+			localStorage.setItem(ACTIVE_ACADEMIC_YEAR_KEY, String(data.academic_year));
 			setIsOtpOpen(false);
 			navigate({
 				to: "/timetable",
@@ -136,6 +156,9 @@ export function SectionSearch({ year }: { year: number }) {
 			});
 		} catch (err: any) {
 			setOtpError(err.message || "Invalid OTP code.");
+			if (err.status === 429) {
+				toast.error(err.message || "Too many failed attempts. Account locked.");
+			}
 		} finally {
 			setIsVerifyingOtp(false);
 		}
@@ -407,10 +430,12 @@ export function SectionSearch({ year }: { year: number }) {
 						<button
 							type="button"
 							onClick={handleSendOtp}
-							disabled={isSendingOtp}
+							disabled={isSendingOtp || resendCooldown > 0}
 							className="w-full h-12 text-brand hover:text-brand-active font-semibold text-sm transition-colors text-center cursor-pointer disabled:opacity-50"
 						>
-							Resend Code
+							{resendCooldown > 0
+								? `Resend Code (${resendCooldown}s)`
+								: "Resend Code"}
 						</button>
 						<button
 							type="button"

--- a/webapp/src/lib/storage.ts
+++ b/webapp/src/lib/storage.ts
@@ -1,5 +1,8 @@
-const STORAGE_KEY = "kiit-time:selected-sections";
-const LAST_SEEN_ANNOUNCEMENT_KEY = "kiit-time:last-seen-announcement";
+export const STORAGE_KEY = "kiit-time:selected-sections";
+export const LAST_SEEN_ANNOUNCEMENT_KEY = "kiit-time:last-seen-announcement";
+export const ACTIVE_ROLL_NO_KEY = "kiit-time:active-roll-no";
+export const ACTIVE_ACADEMIC_YEAR_KEY = "kiit-time:active-academic-year";
+
 
 export function getSavedSectionIds(): number[] | null {
 	try {

--- a/webapp/src/routes/index.test.tsx
+++ b/webapp/src/routes/index.test.tsx
@@ -26,6 +26,8 @@ vi.mock("#/lib/api", () => ({
 vi.mock("#/lib/storage", () => ({
 	getSavedSectionIds: vi.fn(),
 	saveSectionIds: vi.fn(),
+	ACTIVE_ROLL_NO_KEY: "kiit-time:active-roll-no",
+	ACTIVE_ACADEMIC_YEAR_KEY: "kiit-time:active-academic-year",
 }));
 
 describe("Landing Component (Web Onboarding)", () => {

--- a/webapp/src/routes/timetable.tsx
+++ b/webapp/src/routes/timetable.tsx
@@ -30,6 +30,8 @@ import { shareTimetable } from "#/lib/share";
 import {
 	getLastSeenAnnouncementId,
 	setLastSeenAnnouncementId,
+	ACTIVE_ROLL_NO_KEY,
+	ACTIVE_ACADEMIC_YEAR_KEY,
 } from "#/lib/storage";
 
 const DAYS = ["MON", "TUE", "WED", "THU", "FRI", "SAT"] as const;
@@ -50,9 +52,9 @@ function TimetablePage() {
 	const { section_id } = Route.useSearch();
 	const { data, isLoading, isError } = useTimetable(section_id);
 
-	const activeRollNo = localStorage.getItem("kiit-time:active-roll-no");
+	const activeRollNo = localStorage.getItem(ACTIVE_ROLL_NO_KEY);
 	const activeAcademicYear = localStorage.getItem(
-		"kiit-time:active-academic-year",
+		ACTIVE_ACADEMIC_YEAR_KEY,
 	);
 
 	function handleEditSection() {
@@ -115,6 +117,8 @@ function TimetablePage() {
 
 	function handleReset() {
 		localStorage.removeItem("kiit-time:selected-sections");
+		localStorage.removeItem(ACTIVE_ROLL_NO_KEY);
+		localStorage.removeItem(ACTIVE_ACADEMIC_YEAR_KEY);
 		navigate({ to: "/" });
 	}
 


### PR DESCRIPTION
This pull request implements robust storage and reset logic for persisting the user's active roll number and academic year across both the web and mobile apps. It ensures these values are set after onboarding and OTP verification, and properly cleared on reset. Additionally, it introduces user-friendly OTP resend cooldowns and error handling for rate limiting. The changes also improve maintainability by centralizing storage key constants and abstracting platform-specific storage access.

**User Data Persistence & Reset**

* Added `setActiveRollNo`, `setActiveAcademicYear`, `clearActiveRollNo`, and `clearActiveAcademicYear` functions to `mobile/src/lib/storage.ts`, and ensured they're called after onboarding and OTP verification in `mobile/src/app/index.tsx` and `mobile/src/app/select/sections.tsx`. [[1]](diffhunk://#diff-d737a3115c1b4b73de0cebf8240bbb48152f6a9db9a0c9bd8c350304580c92b9R1-R10) [[2]](diffhunk://#diff-ad61bdffaec12584cc0e249e61950d216a18bbb1a15cb228223fc9bbd8f62353R1-R11) [[3]](diffhunk://#diff-1a042a9653e3d90f16fd5f6f4f8c6ba7159441f90802bdbdbd4b8296a7cca737R58-R90) [[4]](diffhunk://#diff-ada1d481157776d6a1d74c4dd1c0707cb284d8a1b2580d87905c9d729d56f88fL11-R11) [[5]](diffhunk://#diff-ada1d481157776d6a1d74c4dd1c0707cb284d8a1b2580d87905c9d729d56f88fR63-R64) [[6]](diffhunk://#diff-15ccab39be763d640e568f274d90593e150ae36705c515f5a08e25aed36b897fL19-R19) [[7]](diffhunk://#diff-15ccab39be763d640e568f274d90593e150ae36705c515f5a08e25aed36b897fR160-R169)
* Defined and exported `ACTIVE_ROLL_NO_KEY` and `ACTIVE_ACADEMIC_YEAR_KEY` in both web and mobile storage modules, replacing raw strings throughout the codebase. [[1]](diffhunk://#diff-ebc2efb5956b81637e0bc8f8bcf0547fd7dcf41def302cd76813ffabecfdc35cR1-R10) [[2]](diffhunk://#diff-786e62aff7ac324c608f842d6baf47c4a9b0309701872eeba7048ab2e3b180ddL1-R5) [[3]](diffhunk://#diff-5221559442317fa56a92be86c1206ea47ec4a5d285d83a4e11ddb6aa36534afdL15-R15) [[4]](diffhunk://#diff-5221559442317fa56a92be86c1206ea47ec4a5d285d83a4e11ddb6aa36534afdR40-R41) [[5]](diffhunk://#diff-21d02a00e9ee4848f57202a2af773bf4ea6c751feedee78afe02737039a0c500L25-R25) [[6]](diffhunk://#diff-21d02a00e9ee4848f57202a2af773bf4ea6c751feedee78afe02737039a0c500R150-R161)
* Updated reset logic in `webapp/src/routes/timetable.tsx` to clear both keys using `localStorage.removeItem()`.

**OTP Resend Cooldown & Rate Limiting**

* Implemented a 60-second cooldown timer on the "Resend OTP" button in both web and mobile OTP flows, disabling the button and showing a countdown. [[1]](diffhunk://#diff-3b636089ac96cb2d3be6dfaf6ff747b4920f58915f1c9cc5f589eac29dc82dcaL7-R12) [[2]](diffhunk://#diff-15ccab39be763d640e568f274d90593e150ae36705c515f5a08e25aed36b897fR76-R85) [[3]](diffhunk://#diff-15ccab39be763d640e568f274d90593e150ae36705c515f5a08e25aed36b897fL404-R433) [[4]](diffhunk://#diff-21d02a00e9ee4848f57202a2af773bf4ea6c751feedee78afe02737039a0c500R42-R50) [[5]](diffhunk://#diff-21d02a00e9ee4848f57202a2af773bf4ea6c751feedee78afe02737039a0c500R124-R136) [[6]](diffhunk://#diff-21d02a00e9ee4848f57202a2af773bf4ea6c751feedee78afe02737039a0c500L410-R438)
* Added handling for 429 (Too Many Requests) and lockout errors on OTP send/verify, displaying user-friendly toasts and adjusting cooldowns accordingly. [[1]](diffhunk://#diff-3b636089ac96cb2d3be6dfaf6ff747b4920f58915f1c9cc5f589eac29dc82dcaL7-R12) [[2]](diffhunk://#diff-15ccab39be763d640e568f274d90593e150ae36705c515f5a08e25aed36b897fR134-R146) [[3]](diffhunk://#diff-15ccab39be763d640e568f274d90593e150ae36705c515f5a08e25aed36b897fR160-R169) [[4]](diffhunk://#diff-21d02a00e9ee4848f57202a2af773bf4ea6c751feedee78afe02737039a0c500R124-R136) [[5]](diffhunk://#diff-21d02a00e9ee4848f57202a2af773bf4ea6c751feedee78afe02737039a0c500R150-R161)

**Developer Experience & Testing**

* Updated tests and mocks to include the new storage key constants.
* Provided detailed documentation and checklists in `.md` files describing the problem, solution, and testing strategy. [[1]](diffhunk://#diff-34a063495ffa8276bd7d439c96cd95d715cc01d3b8be2661421428309694831eR1-R44) [[2]](diffhunk://#diff-d737a3115c1b4b73de0cebf8240bbb48152f6a9db9a0c9bd8c350304580c92b9R1-R10) [[3]](diffhunk://#diff-ebc2efb5956b81637e0bc8f8bcf0547fd7dcf41def302cd76813ffabecfdc35cR1-R10) [[4]](diffhunk://#diff-ad61bdffaec12584cc0e249e61950d216a18bbb1a15cb228223fc9bbd8f62353R1-R11)

These changes ensure consistent user experience across platforms, reduce the risk of storage key typos, and improve maintainability and clarity for future development.…mit UI (#36)